### PR TITLE
Enable post creation

### DIFF
--- a/handlers/post_handler.go
+++ b/handlers/post_handler.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"forum/middleware"
+	"forum/models"
+	"forum/repository"
+	"forum/utils"
+)
+
+// PostHandler handles post related endpoints
+type PostHandler struct {
+	PostRepo *repository.PostRepository
+}
+
+// NewPostHandler creates a new PostHandler
+func NewPostHandler(repo *repository.PostRepository) *PostHandler {
+	return &PostHandler{PostRepo: repo}
+}
+
+// CreatePost creates a new post for the authenticated user
+func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req struct {
+		CategoryID int    `json:"category_id"`
+		Title      string `json:"title"`
+		Content    string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.ErrorResponse(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.CategoryID == 0 || req.Title == "" || req.Content == "" {
+		utils.ErrorResponse(w, "Category, title and content are required", http.StatusBadRequest)
+		return
+	}
+
+	post := models.Post{
+		UserID:     user.ID,
+		CategoryID: req.CategoryID,
+		Title:      req.Title,
+		Content:    req.Content,
+	}
+
+	created, err := h.PostRepo.Create(post)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to create post", http.StatusInternalServerError)
+		return
+	}
+
+	utils.JSONResponse(w, created, http.StatusCreated)
+}

--- a/repository/post_repository.go
+++ b/repository/post_repository.go
@@ -2,7 +2,10 @@ package repository
 
 import (
 	"database/sql"
+	"time"
+
 	"forum/models"
+	"forum/utils"
 )
 
 type PostRepository struct {
@@ -33,4 +36,16 @@ func (r *PostRepository) GetAllPosts() ([]models.Post, error) {
 	}
 
 	return posts, nil
+}
+
+// Create inserts a new post into the database
+func (r *PostRepository) Create(post models.Post) (*models.Post, error) {
+	post.ID = utils.GenerateUUID()
+	post.CreatedAt = time.Now()
+	_, err := r.db.Exec(`INSERT INTO posts (post_id, user_id, category_id, title, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		post.ID, post.UserID, post.CategoryID, post.Title, post.Content, post.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &post, nil
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -23,6 +23,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	// Create handlers
 	authHandler := handlers.NewAuthHandler(userRepo, sessionRepo)
 	categoryHandler := handlers.NewCategoryHandler(categoryRepo)
+	postHandler := handlers.NewPostHandler(postRepo)
 
 	// Create middleware
 	registerLimiter := middleware.NewRateLimiter()
@@ -40,6 +41,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	mux.Handle("/forum/api/session/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.Login)))
 	mux.HandleFunc("/forum/api/session/logout", authHandler.Logout)
 	mux.Handle("/forum/api/session/verify", corsMiddleware.Handler(http.HandlerFunc(authHandler.VerifySession)))
+	mux.Handle("/forum/api/posts", corsMiddleware.Handler(authMiddleware.RequireAuth(http.HandlerFunc(postHandler.CreatePost))))
 
 	// Apply middleware to all routes
 	return authMiddleware.Authenticate(mux)

--- a/ui/static/js/modal.js
+++ b/ui/static/js/modal.js
@@ -5,7 +5,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const submitBtn = document.getElementById("submit-post");
   const postTitle = document.getElementById("post-title");
   const postBody = document.getElementById("post-body");
-  const commentBtn = document.getElementById("comment-btn");
+  const categorySelect = document.getElementById("post-category");
 
   createBtn.onclick = () => {
     modal.classList.remove("hidden");
@@ -15,16 +15,46 @@ document.addEventListener("DOMContentLoaded", () => {
     modal.classList.add("hidden");
   };
 
-  submitBtn.onclick = () => {
+  // Populate categories
+  fetch("http://localhost:8080/forum/api/categories")
+    .then((res) => res.json())
+    .then((categories) => {
+      categorySelect.innerHTML =
+        '<option value="" disabled selected>Select category</option>';
+      categories.forEach((c) => {
+        const opt = document.createElement("option");
+        opt.value = c.id;
+        opt.textContent = c.name;
+        categorySelect.appendChild(opt);
+      });
+    })
+    .catch((err) => console.error("Failed to load categories", err));
+
+  submitBtn.onclick = async () => {
     const title = postTitle.value.trim();
     const content = postBody.value.trim();
+    const categoryId = parseInt(categorySelect.value, 10);
 
-    if (!title || !content) return;
+    if (!title || !content || isNaN(categoryId)) return;
 
-    //Add logic for POSTing to server
-
-    postTitle.value = "";
-    postBody.value = "";
-    modal.classList.add("hidden");
+    try {
+      const res = await fetch("http://localhost:8080/forum/api/posts", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          content,
+          category_id: categoryId,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to create post");
+      postTitle.value = "";
+      postBody.value = "";
+      modal.classList.add("hidden");
+      window.location.reload();
+    } catch (err) {
+      console.error("Create post failed", err);
+    }
   };
 });

--- a/ui/static/templates/user.html
+++ b/ui/static/templates/user.html
@@ -96,9 +96,6 @@ fetch("http://localhost:8080/forum/api/session/verify", {
         <label for="post-category" class="modal-label">Category</label>
         <select id="post-category">
           <option value="" disabled selected>Select category</option>
-          <option value="general">General</option>
-          <option value="feedback">Feedback</option>
-          <option value="help">Help</option>
         </select>
 
         <button id="submit-post">Submit</button>


### PR DESCRIPTION
## Summary
- allow saving posts in repository
- add API endpoint to create posts
- load categories dynamically and post data from front-end

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842baa93300832493f2d8bbad2d373b