### PR TITLE
Implement comment creation endpoint

### DIFF
--- a/handlers/comment_handler.go
+++ b/handlers/comment_handler.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"forum/middleware"
+	"forum/models"
+	"forum/repository"
+	"forum/utils"
+)
+
+// CommentHandler handles comment related endpoints
+type CommentHandler struct {
+	CommentRepo *repository.CommentRepository
+}
+
+// NewCommentHandler creates a new CommentHandler
+func NewCommentHandler(repo *repository.CommentRepository) *CommentHandler {
+	return &CommentHandler{CommentRepo: repo}
+}
+
+// CreateComment creates a new comment on a post for the authenticated user
+func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req struct {
+		PostID  string `json:"post_id"`
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.ErrorResponse(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.PostID == "" || req.Content == "" {
+		utils.ErrorResponse(w, "Post ID and content are required", http.StatusBadRequest)
+		return
+	}
+
+	comment := models.Comment{
+		PostID:  req.PostID,
+		UserID:  user.ID,
+		Content: req.Content,
+	}
+
+	created, err := h.CommentRepo.Create(comment)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to create comment", http.StatusInternalServerError)
+		return
+	}
+
+	utils.JSONResponse(w, created, http.StatusCreated)
+}

--- a/instructions.md
+++ b/instructions.md
@@ -24,6 +24,13 @@ curl -X POST http://localhost:8080/forum/api/session/login \
 curl -X POST http://localhost:8080/forum/api/session/logout \
   -b cookies.txt
 
+## Create a comment
+
+curl -X POST http://localhost:8080/forum/api/comments \
+  -H "Content-Type: application/json" \
+  -d '{"post_id":"<POST_ID>","content":"Nice post!"}' \
+  -b cookies.txt
+
 
 ## Front
 

--- a/repository/comment_repository.go
+++ b/repository/comment_repository.go
@@ -2,7 +2,10 @@ package repository
 
 import (
 	"database/sql"
+	"time"
+
 	"forum/models"
+	"forum/utils"
 )
 
 type CommentRepository struct {
@@ -33,4 +36,16 @@ func (r *CommentRepository) GetAllComments() ([]models.Comment, error) {
 	}
 
 	return comments, nil
+}
+
+// Create inserts a new comment into the database
+func (r *CommentRepository) Create(comment models.Comment) (*models.Comment, error) {
+	comment.ID = utils.GenerateUUID()
+	comment.CreatedAt = time.Now()
+	_, err := r.db.Exec(`INSERT INTO comments (comment_id, post_id, user_id, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+		comment.ID, comment.PostID, comment.UserID, comment.Content, comment.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &comment, nil
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -24,6 +24,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	authHandler := handlers.NewAuthHandler(userRepo, sessionRepo)
 	categoryHandler := handlers.NewCategoryHandler(categoryRepo)
 	postHandler := handlers.NewPostHandler(postRepo)
+	commentHandler := handlers.NewCommentHandler(commentRepo)
 
 	// Create middleware
 	registerLimiter := middleware.NewRateLimiter()
@@ -42,6 +43,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	mux.HandleFunc("/forum/api/session/logout", authHandler.Logout)
 	mux.Handle("/forum/api/session/verify", corsMiddleware.Handler(http.HandlerFunc(authHandler.VerifySession)))
 	mux.Handle("/forum/api/posts", corsMiddleware.Handler(authMiddleware.RequireAuth(http.HandlerFunc(postHandler.CreatePost))))
+	mux.Handle("/forum/api/comments", corsMiddleware.Handler(authMiddleware.RequireAuth(http.HandlerFunc(commentHandler.CreateComment))))
 
 	// Apply middleware to all routes
 	return authMiddleware.Authenticate(mux)


### PR DESCRIPTION
## Summary
- allow posting comments to posts
- add comment creation handler and repository method
- expose new `/forum/api/comments` route
- document curl instructions for posting a comment

## Testing
- `go vet ./...` *(fails: fetching Go toolchain forbidden)*
- `go build ./...` *(fails: fetching Go toolchain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc1a9d10832489c726b35e2b9e73